### PR TITLE
Update sniff class name

### DIFF
--- a/Travelopia-WordPress/Sniffs/Whitespace/NoFunctionEmptyFirstLineSniff.php
+++ b/Travelopia-WordPress/Sniffs/Whitespace/NoFunctionEmptyFirstLineSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sniff: NoFunctionEmptyFirstLine.
+ * Sniff: NoFunctionEmptyFirstLineSniff.
  *
  * @package travelopia-coding-standards
  */
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 /**
  * Sniff to check if the first line in a function is not empty.
  */
-class NoFunctionEmptyFirstLine implements Sniff {
+class NoFunctionEmptyFirstLineSniff implements Sniff {
 
 	/**
 	 * Register the sniff.


### PR DESCRIPTION
# Description
With introduction of https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/src/Util/Common.php#L547-L557 , class name must end with the "Sniff", else an error is thrown - 

<img width="863" alt="image" src="https://github.com/user-attachments/assets/d3f33766-d369-4e7f-8aa1-3c72383dbb8b" />
