### PR TITLE
WP-149 Removed docblock alignment rule from exclude list

### DIFF
--- a/Travelopia-WordPress/ruleset.xml
+++ b/Travelopia-WordPress/ruleset.xml
@@ -68,7 +68,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturn" />
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturnNotVoid" />
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital" />
-		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamName" />
 		<exclude name="Squiz.Commenting.InlineComment.DocBlock" />
 		<exclude name="Squiz.Commenting.InlineComment.NotCapital" />
 		<exclude name="Squiz.Commenting.LongConditionClosingComment" />


### PR DESCRIPTION
This PR removes the Doc block alignment rule from the exclude list after the variable name.
Now the `phpcbf` can fix the alignment issues.