### PR TITLE
Remove deprecated rule

### DIFF
--- a/Travelopia-WordPress/ruleset.xml
+++ b/Travelopia-WordPress/ruleset.xml
@@ -20,6 +20,7 @@
 	-->
 
 	<rule ref="WordPress-Extra">
+		<exclude name="Generic.Functions.CallTimePassByReference" />
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />


### PR DESCRIPTION
This PR removes the deprecated rule "Generic.Functions.CallTimePassByReference" - https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/921

<img width="627" alt="image" src="https://github.com/user-attachments/assets/e965a0bc-61ba-4058-9883-617f78fc91a7" />
