### PR TITLE
Fix : Conflicts with PHPCS

### DIFF
--- a/php-cs-fixer/Fixers/SpacesInsideArrayBracketsFixer.php
+++ b/php-cs-fixer/Fixers/SpacesInsideArrayBracketsFixer.php
@@ -149,8 +149,12 @@ final class SpacesInsideArrayBracketsFixer extends AbstractFixer
 			}
 		}
 
-		if ( ! $isVariable && ! $isClassConstant ) {
-			// Remove any existing spaces for non-variables.
+		// Check if it's a string literal (T_CONSTANT_ENCAPSED_STRING) or integer literal (T_LNUMBER).
+		$isStringOrInteger = $tokens[ $nextIndex ]->isGivenKind( [ T_CONSTANT_ENCAPSED_STRING, T_LNUMBER ] );
+
+		// If it's a string or integer literal, ensure no spaces (WordPress rule).
+		if ( $isStringOrInteger ) {
+			// Remove any existing spaces for string/integer literals.
 			if ( $tokens[ $index + 1 ]->isWhitespace() ) {
 				$tokens->clearAt( $index + 1 );
 				$closeIndex = $tokens->findBlockEnd( Tokens::BLOCK_TYPE_INDEX_SQUARE_BRACE, $index );

--- a/php-cs-fixer/Fixers/SwitchCaseBodyOnNextLineFixer.php
+++ b/php-cs-fixer/Fixers/SwitchCaseBodyOnNextLineFixer.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Travelopia\WordPressCodingStandards\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+/**
+ * Fixer to ensure CASE and DEFAULT body starts on the line following the statement.
+ * This complies with PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE.
+ */
+final class SwitchCaseBodyOnNextLineFixer extends AbstractFixer
+{
+	public function getDefinition(): FixerDefinitionInterface
+	{
+		return new FixerDefinition(
+			'The CASE and DEFAULT body must start on the line following the statement (PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE).',
+			[
+				new CodeSample(
+					"<?php\nswitch ( \$var ) {\n\tcase 'value':\n\n\t\t\$a = 1;\n\t\tbreak;\n}\n",
+				),
+			],
+		);
+	}
+
+	public function isCandidate( Tokens $tokens ): bool
+	{
+		return $tokens->isTokenKindFound( T_SWITCH )
+			|| $tokens->isTokenKindFound( T_CASE )
+			|| $tokens->isTokenKindFound( T_DEFAULT );
+	}
+
+	protected function applyFix( SplFileInfo $file, Tokens $tokens ): void
+	{
+		for ( $index = $tokens->count() - 1; 0 <= $index; --$index ) {
+			// Check for case statements.
+			if ( $tokens[ $index ]->isGivenKind( T_CASE ) ) {
+				$this->fixCaseBody( $tokens, $index );
+			}
+
+			// Check for default statements.
+			if ( $tokens[ $index ]->isGivenKind( T_DEFAULT ) ) {
+				$this->fixDefaultBody( $tokens, $index );
+			}
+		}
+	}
+
+	/**
+	 * Fix case statement to ensure body starts on next line.
+	 */
+	private function fixCaseBody( Tokens $tokens, int $caseIndex ): void
+	{
+		// Find the colon after the case value.
+		$colonIndex = $tokens->getNextTokenOfKind( $caseIndex, [ ':' ] );
+
+		if ( null === $colonIndex ) {
+			return;
+		}
+
+		// Get the next token after the colon.
+		$nextIndex = $colonIndex + 1;
+
+		if ( ! isset( $tokens[ $nextIndex ] ) ) {
+			return;
+		}
+
+		// If the next token is whitespace, check if it has multiple newlines.
+		if ( $tokens[ $nextIndex ]->isWhitespace() ) {
+			$whitespace = $tokens[ $nextIndex ]->getContent();
+			$newlineCount = substr_count( $whitespace, "\n" );
+
+			// If there are 2 or more newlines (meaning a blank line), remove the extra ones.
+			if ( $newlineCount >= 2 ) {
+				// Extract the indentation from the last line (the line where code should start).
+				$parts = explode( "\n", $whitespace );
+				$indentation = end( $parts );
+
+				// Replace with single newline + indentation.
+				$tokens[ $nextIndex ] = new Token( [ T_WHITESPACE, "\n" . $indentation ] );
+			}
+		}
+	}
+
+	/**
+	 * Fix default statement to ensure body starts on next line.
+	 */
+	private function fixDefaultBody( Tokens $tokens, int $defaultIndex ): void
+	{
+		// Find the colon after default.
+		$colonIndex = $tokens->getNextTokenOfKind( $defaultIndex, [ ':' ] );
+
+		if ( null === $colonIndex ) {
+			return;
+		}
+
+		// Get the next token after the colon.
+		$nextIndex = $colonIndex + 1;
+
+		if ( ! isset( $tokens[ $nextIndex ] ) ) {
+			return;
+		}
+
+		// If the next token is whitespace, check if it has multiple newlines.
+		if ( $tokens[ $nextIndex ]->isWhitespace() ) {
+			$whitespace = $tokens[ $nextIndex ]->getContent();
+			$newlineCount = substr_count( $whitespace, "\n" );
+
+			// If there are 2 or more newlines (meaning a blank line), remove the extra ones.
+			if ( $newlineCount >= 2 ) {
+				// Extract the indentation from the last line (the line where code should start).
+				$parts = explode( "\n", $whitespace );
+				$indentation = end( $parts );
+
+				// Replace with single newline + indentation.
+				$tokens[ $nextIndex ] = new Token( [ T_WHITESPACE, "\n" . $indentation ] );
+			}
+		}
+	}
+
+	public function getName(): string
+	{
+		return 'Travelopia/switch_case_body_on_next_line';
+	}
+
+	public function getPriority(): int
+	{
+		// Should run after other formatting rules but before blank line rules.
+		return -10;
+	}
+}

--- a/php-cs-fixer/TravelopiaFixersConfig.php
+++ b/php-cs-fixer/TravelopiaFixersConfig.php
@@ -8,6 +8,7 @@ use Travelopia\WordPressCodingStandards\Fixers\BlankLineBeforeCommentFixer;
 use Travelopia\WordPressCodingStandards\Fixers\CommentPunctuationFixer;
 use Travelopia\WordPressCodingStandards\Fixers\DocBlockOnNewLineFixer;
 use Travelopia\WordPressCodingStandards\Fixers\SpacesInsideArrayBracketsFixer;
+use Travelopia\WordPressCodingStandards\Fixers\SwitchCaseBodyOnNextLineFixer;
 
 /**
  * Helper class to easily create a PHP-CS-Fixer config with Travelopia custom fixers.
@@ -40,6 +41,7 @@ class TravelopiaFixersConfig
 			new CommentPunctuationFixer(),
 			new BlankLineAfterControlStructureFixer(),
 			new DocBlockOnNewLineFixer(),
+			new SwitchCaseBodyOnNextLineFixer(),
 		];
 	}
 
@@ -117,6 +119,9 @@ class TravelopiaFixersConfig
 
 			// Custom rule: docblock on new line.
 			'Travelopia/docblock_on_new_line' => true,
+
+			// Custom rule: switch case body on next line (PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE).
+			'Travelopia/switch_case_body_on_next_line' => true,
 
 			// Array indentation.
 			'array_indentation' => true,
@@ -225,6 +230,9 @@ class TravelopiaFixersConfig
 
 			// Disable statement indentation to allow proper indentation in template files.
 			'statement_indentation' => false,
+
+			// The @PSR12 preset already handles this correctly, but we ensure switch_case_space is enabled.
+			'switch_case_space' => true,
 		];
 	}
 }


### PR DESCRIPTION
### Issue
- Jira Ticket : https://tuispecialist.atlassian.net/browse/MR-1851
- Auto-fixes implemented by `php-cs-fixer` caused errors/warnings in our `phpcs` lint

#### Errors / Warnings
- Error : `Array keys must be surrounded by spaces unless they contain a string or an integer.`
- Rule : `WordPress.Arrays.ArrayKeySpacingRestrictions.NoSpacesAroundArrayKeys`
---
- Error : `The CASE body must start on the line following the statement`
- Rule : `PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE`
---
- Error : `The DEFAULT body must start on the line following the statement`
- Rule : `PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineDEFAULT`
---

### Fixes : 
- Added custom fixer SwitchCaseBodyOnNextLineFixer to collapse extra blank lines after case/default labels before their bodies.
- Adjusted SpacesInsideArrayBracketsFixer to strip bracket padding when indexing with string or integer literals, keeping spacing only for variables/constants.
- Registered the new fixer and rule in TravelopiaFixersConfig, ensuring switch_case_space stays enabled.